### PR TITLE
URLエンコードされたタブグループ名を正しくデコード

### DIFF
--- a/background.js
+++ b/background.js
@@ -27,7 +27,8 @@ chrome.webNavigation.onBeforeNavigate.addListener(
       }
 
       // URLパスから値を抽出（先頭の"/"を除く）
-      const value = url.pathname.substring(1);
+      const rawValue = url.pathname.substring(1);
+      const value = decodeURIComponent(rawValue);
 
       if (!value) {
         console.warn('TabGroup Trigger: 値が指定されていません');


### PR DESCRIPTION
## 問題
日本語や括弧などの特殊文字を含むタブグループ名（例: `github(開発)`）でURLトリガーが動作しませんでした。

## 原因
`url.pathname` から取得した値がURLエンコードされたまま（`github(%E9%96%8B%E7%99%BA)`）グループ名と比較されていました。

## 修正内容
`decodeURIComponent()` を使用してURLパスをデコードするように修正しました。

### 変更箇所
- `background.js`: URLパス抽出時に `decodeURIComponent()` を追加

## 動作確認
以下のURLで正しく動作することを確認：
- `https://extension.tabgroup-trigger/github(開発)`
- `https://extension.tabgroup-trigger/github%28%E9%96%8B%E7%99%BA%29`

どちらの形式でも `github(開発)` という名前のタブグループに正しく切り替わります。

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)