### PR TITLE
fix: タブグループの最後に選択したタブ位置を永続化

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,15 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [
     "tabs",
     "tabGroups",
     "webNavigation",
-    "sessions"
+    "sessions",
+    "storage"
   ],
   "host_permissions": [
     "https://extension.tabgroup-trigger/*"


### PR DESCRIPTION
## 概要
タブグループで最後に選択していたタブの位置情報を永続化し、service workerが再起動しても情報を保持できるように修正しました。

## 変更内容

### 1. chrome.storage.localを使った永続化
- メモリ上のMapから`chrome.storage.local`に変更
- `getLastActiveTab()`関数: ストレージから最後のアクティブタブIDを取得
- `setLastActiveTab()`関数: ストレージに最後のアクティブタブIDを保存

### 2. switchTabGroup関数のリファクタリング
- タブグループ切り替えの責務のみに集中
- `triggerTabId`パラメータを削除
- `closeTab`呼び出しを関数外に移動

### 3. 処理順序の改善
- トリガータブのクローズを先に実行
- その後にタブグループ切り替えを実行
- リソースの早期解放と動作の安定化を実現

### 4. バージョン更新
- v1.0.0 → v1.0.1

## 修正した問題
service workerが停止・再起動すると、各タブグループで最後に選択していたタブの位置情報が失われ、グループ切り替え時に常に最初のタブがアクティブになってしまう問題を修正しました。

## テスト
- 複数のタブグループで異なるタブを選択
- トリガーURLでグループを切り替え
- 長時間待機後（service worker停止後）に再度グループ切り替えを実施
- 正しいタブが選択されることを確認

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)